### PR TITLE
Fix for poll url returning undefined

### DIFF
--- a/src/paynow.ts
+++ b/src/paynow.ts
@@ -5,7 +5,7 @@ const http = require("request-promise-native");
  *
  * @property {String} reference - merchant transaction reference .
  * @property {String} amount - original amount for the transaction.
- * @property {String} paynowreference  - the Paynow transaction reference.
+ * @property {String} paynowReference  - the Paynow transaction reference.
  * @property {String} pollUrl - the URL on Paynow the merchant can poll to confirm the transaction’s status.
  * @property {String} status - transaction status returned from paynow.
  * @property {String} error - error message sent from Paynow  (if any).
@@ -67,9 +67,11 @@ class InitResponse {
     if (!this.success) {
       this.error = data.error;
     } else {
+      
+      this.pollUrl = data.pollurl;
+
       if (this.hasRedirect) {
         this.redirectUrl = data.browserurl;
-        this.pollUrl = data.pollurl;
       }
 
       if (typeof data.instructions !== "undefined") {


### PR DESCRIPTION
Fixes the issue expressed in #7. 

The statement for setting a poll url had been encapsulated in a conditional check this.hasRedirect. This bug was causing poll urls to not be set in mobile transactions