### PR TITLE
Removed buggy email validation. Added email validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ paynow.send(payment).then(response => {
 If you want to send an express (mobile) checkout request instead, the only thing that differs is the last step. You make a call to the `sendMobile` in the `paynow` object
 instead of the `send` method.
 
-The `sendMobile` method unlike the `send` method takes in two additional arguments i.e The phone number to send the payment request to and the mobile money method to use for the request. **Note that currently only ecocash is supported**
+The `sendMobile` method unlike the `send` method takes in two additional arguments i.e The phone number to send the payment request to and the mobile money method to use for the request. **Note that currently only Ecocash and OneMoney are supported**
 
 ```javascript
 paynow.sendMobile(payment, '0777000000', 'ecocash').then(response => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paynow",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Node.JS SDK for Zimbabwe's Leading Payment Gateway, Paynow",
   "main": "dist/index.js",
   "scripts": {

--- a/src/paynow.ts
+++ b/src/paynow.ts
@@ -171,6 +171,8 @@ export default class Paynow {
   initMobile(payment: Payment, phone: string, method: string) {
     this.validate(payment);
 
+    if(!this.isValidEmail(payment.authEmail)) this.fail("Invalid email. Please ensure that you pass a valid email address when initiating a mobile payment");
+
     let data = this.buildMobile(payment, phone, method);
 
     return http(
@@ -185,6 +187,20 @@ export default class Paynow {
     }).catch(function(err) {
       console.log("An error occured while initiating transaction", err)
     });;
+  }
+
+  /**
+   * Validates whether an email address is valid or not
+   * 
+   * @param {string} emailAddress The email address to validate
+   * 
+   * @returns {boolean} A value indicating an email is valid or not
+   */
+  isValidEmail(emailAddress: string) {
+    if(!emailAddress || emailAddress.length === 0) return false;
+
+    return /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/
+          .test(emailAddress)
   }
 
   /**
@@ -328,11 +344,6 @@ export default class Paynow {
     phone: string,
     method: string
   ): Error | { [key: string]: string } {
-    if (payment.authEmail.length <= 0) {
-      throw new Error(
-        "Auth email is required for mobile transactions. You can pass it as the second parameter to the createPayment method call"
-      );
-    }
 
     let data: { [key: string]: string } = {
       resulturl: this.resultUrl,


### PR DESCRIPTION
There's been a few reports about weird behaviors on the NodeJS SDK when it comes to mobile payments and email validation on there. 

Looking through the code, it seems like there was a big fat bug that was validating the authEmail for a transaction by checking the length of the string. Which is fine I guess. But it fails everytime an authEmail is not passed, because it's accessing the property .length of undefined.

This tries to fix that, I guess and stop those reports


https://forums.paynow.co.zw/t/typeerror-cannot-read-property-length-of-undefined/1634
https://forums.paynow.co.zw/t/auth-email-error/1088